### PR TITLE
Add skills section with hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Portfolio</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f4f4f4;
+      margin: 0;
+      padding: 0;
+    }
+    #skills {
+      padding: 2rem;
+      text-align: center;
+    }
+    .skills-grid {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
+    }
+    .skill {
+      background: white;
+      width: 100px;
+      height: 100px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.3s, box-shadow 0.3s;
+    }
+    .skill:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    }
+    .skill .icon {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <section id="skills">
+    <h2>Skills</h2>
+    <div class="skills-grid">
+      <div class="skill">
+        <div class="icon">📄</div>
+        <div>HTML</div>
+      </div>
+      <div class="skill">
+        <div class="icon">🎨</div>
+        <div>CSS</div>
+      </div>
+      <div class="skill">
+        <div class="icon">⚙️</div>
+        <div>JavaScript</div>
+      </div>
+    </div>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add portfolio page featuring a **Skills** section with sample icons
- Highlight skills on hover with smooth translation and shadow effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ece14b188328950bea9f14e0d10c